### PR TITLE
Hide 'Previously Searched' section when there are no prior searches.

### DIFF
--- a/src/components/Demo.jsx
+++ b/src/components/Demo.jsx
@@ -2,188 +2,100 @@ import { useState, useEffect } from 'react';
 import { copy, linkIcon, loader, tick } from '../assets';
 import { useLazyGetSummaryQuery } from '../services/article';
 
-// Demo component for article summarization
+// Main demo component for article summarization.
 const Demo = () => {
-
-  // Local state to store the article's URL and its corresponding summary
+  // Local state for tracking the article URL and its summary.
   const [article, setArticle] = useState({
     url: '',
     summary: '',
   });
 
-  // State to manage and store all articles that have been summarized or searched.
+  // Local state to hold all articles that have been processed (summarized or searched).
   const [allArticles, setAllArticles] = useState([]);
 
-  // State to manage the URL that is currently copied to the clipboard.
-  // It's set to a string, with its initial state being an empty string.
+  // State for tracking which URL has recently been copied to the clipboard.
   const [copied, setCopied] = useState('');
 
-  // Hook to trigger the 'getSummary' API query lazily (i.e., on-demand) 
-  // and extract relevant data and status variables
+  // Hook for triggering the getSummary API call lazily and manage its state.
   const [getSummary, { error, isFetching }] = useLazyGetSummaryQuery();
 
-  // Effect hook to initialize the articles state from local storage when the component mounts
+  // Load articles from local storage on component mount.
   useEffect(() => {
-
-    // Retrieves the 'articles' item from local storage and parses it into a JavaScript object
-    const articlesFromLocalStorage = JSON.parse(
-      localStorage.getItem('articles')
-    );
-
-    // If there are articles found in local storage, updates the state with those articles
+    const articlesFromLocalStorage = JSON.parse(localStorage.getItem('articles'));
     if (articlesFromLocalStorage) {
       setAllArticles(articlesFromLocalStorage);
     }
+  }, []);
 
-  }, []); // Empty dependency array ensures this effect runs only once, similar to componentDidMount
-
-
-  // Handles the submission event of the article input form
+  // Handle the submission of the URL form.
   const handleSubmit = async (e) => {
-
-    // Prevents the default form submission behavior
     e.preventDefault();
-
-    // Fetches the summary of the article using the `getSummary` API hook 
-    // by passing the current article's URL as a parameter
     const { data } = await getSummary({ articleUrl: article.url });
-
-    // Checks if the fetched data contains a summary
     if (data?.summary) {
-
-      // Creates a new article object with the fetched summary
       const newArticle = { ...article, summary: data.summary }
-
-      // Prepends the new article to the beginning of the existing list of all articles
       const updatedAllArticles = [newArticle, ...allArticles];
-
-      // Updates the local state with the new article data
       setArticle(newArticle);
-
-      // Updates the state with the modified list of all articles
       setAllArticles(updatedAllArticles);
-
-      // Stores the updated list of articles as a string in local storage under the key 'articles'
-      localStorage.setItem('articles', JSON.stringify
-        (updatedAllArticles));
+      // Store the updated list of articles in local storage.
+      localStorage.setItem('articles', JSON.stringify(updatedAllArticles));
     }
   }
 
-  /**
- * Handles the action of copying a URL to the clipboard.
- * 
- * @param {string} copyUrl - The URL to be copied.
- */
+  // Handle copying a URL to clipboard.
   const handleCopy = (copyUrl) => {
-
-    // Set the currently copied URL to the state.
     setCopied(copyUrl);
-
-    // Use the Web API to write the URL to the user's clipboard.
     navigator.clipboard.writeText(copyUrl);
-
-    // Reset the copied state back to 'false' after a 3-second delay.
+    // Reset the copied state after a delay.
     setTimeout(() => setCopied(false), 3000);
   }
 
   return (
     <section className='mt-16 w-full max-w-xl'>
-
-      {/* Search */}
       <div className='flex flex-col w-full gap-2'>
-        <form
-          className='relative flex justify-center items-center'
-          onSubmit={handleSubmit}>
-
-          <img
-            src={linkIcon}
-            alt="link_icon"
-            className='absolute left-0 my-2 ml-3 w-5' />
-
-          <input
-            type="url"
-            placeholder='Enter a URL'
-            value={article.url}
-            onChange={(e) => setArticle({
-              ...
-              article, url: e.target.value
-            })}
-            required
-            className='url_input peer' />
-
-          <button
-            type='submit'
-            className='submit_btn peer-focus:border-gray-700 per-focus:text-gray-700'>
-            ↵
-          </button>
-
+        {/* Form for inputting the article URL */}
+        <form className='relative flex justify-center items-center' onSubmit={handleSubmit}>
+          <img src={linkIcon} alt="link_icon" className='absolute left-0 my-2 ml-3 w-5' />
+          <input type="url" placeholder='Enter a URL' value={article.url} onChange={(e) => setArticle({ ...article, url: e.target.value })} required className='url_input peer' />
+          <button type='submit' className='submit_btn peer-focus:border-gray-700 per-focus:text-gray-700'>↵</button>
         </form>
 
-        {/* Browse URL history */}
-        <div className='flex flex-col gap-1 max-h-60 overflow-y-auto'>
-
-          {/* Previously searched text */}
-          <div className='mt-6 mb-6 flex items-center'>
-            <h2 className='font-satoshi font-bold text-gray-600 text-xl mr-2'>
-              Previously
-            </h2>
-
-            <div className='flex items-center'>
-              <div className='blue_gradient font-satoshi font-bold text-xl'>
-                Searched:
+        {/* Display list of previously searched articles */}
+        {allArticles.length > 0 && (
+          <>
+            <div className='mt-6 mb-6 flex items-center'>
+              <h2 className='font-satoshi font-bold text-gray-600 text-xl mr-2'>Previously</h2>
+              <div className='flex items-center'>
+                <div className='blue_gradient font-satoshi font-bold text-xl'>Searched:</div>
               </div>
             </div>
-          </div>
 
-          {allArticles.map((item, index) => (
-            <div
-
-              // Copy icons
-              key={`link-${index}`}
-              onClick={() => setArticle(item)}
-              className='link_card'>
-              
-              {/* Copy button to allow users to copy the article's URL to the clipboard */}
-              <div className='copy_btn'
-                onClick={() => handleCopy(item.url)}>
-                <img
-
-                  // Display a tick icon if the URL is copied, otherwise show the copy icon 
-                  src={copied === item.url ? tick : copy}
-                  alt="copy_icon"
-                  className='w-[40%] h-[40%] object-contain' />
+            {/* Map over all articles and display each one */}
+            {allArticles.map((item, index) => (
+              <div key={`link-${index}`} onClick={() => setArticle(item)} className='link_card'>
+                <div className='copy_btn' onClick={() => handleCopy(item.url)}>
+                  <img src={copied === item.url ? tick : copy} alt="copy_icon" className='w-[40%] h-[40%] object-contain' />
+                </div>
+                <p className='flex-1 font-satoshi text-blue-700 font-medium text-sm truncate hover:text-blue-900 transition-all duration-300 ease-in-out hover:underline'>
+                  {item.url}
+                </p>
               </div>
-
-              {/* URLs */}
-              <p
-                className='flex-1 font-satoshi text-blue-700 font-medium text-sm truncate hover:text-blue-900 transition-all duration-300 ease-in-out hover:underline'>
-                {item.url}
-              </p>
-
-            </div>
-          ))}
-        </div>
-
+            ))}
+          </>
+        )}
       </div>
 
-      {/* Display results */}
       <div className='my-10 max-w-full flex justify-center items-center'>
+        {/* Display loader while fetching */}
         {isFetching ? (
           <img src={loader} alt='loader' className='w-20 h-20 object-contain' />
         ) : error ? (
-          <p className='font-inter font-bold text-black text-center'>
-            Unexpected hiccup. Let's try that again!
-            <br />
-            <span className='font-satoshi font-normal text-gray-700'>
-              {error?.data?.error}
-            </span>
-          </p>
+          // Display error if there is one.
+          <p className='font-inter font-bold text-black text-center'>Unexpected hiccup. Let's try that again!<br /><span className='font-satoshi font-normal text-gray-700'>{error?.data?.error}</span></p>
         ) : (
+          // Display the article summary if available.
           article.summary && (
             <div className='flex flex-col gap-3'>
-              <h2 className='font-satoshi font-bold text-gray-600 text-xl'>
-                Article <span className='blue_gradient'>Summary</span>
-              </h2>
+              <h2 className='font-satoshi font-bold text-gray-600 text-xl'>Article <span className='blue_gradient'>Summary</span></h2>
               <div className='summary_box'>
                 <p className='font-inter font-medium text-sm text-gray-700'>{article.summary}</p>
               </div>
@@ -191,9 +103,8 @@ const Demo = () => {
           )
         )}
       </div>
-
     </section>
   )
 }
 
-export default Demo
+export default Demo;


### PR DESCRIPTION
# Updates

This PR introduces a usability improvement to the `Demo` component. With this change, users will no longer see the "Previously Searched" section if they haven't made any prior searches, offering a cleaner interface.

**Changes:**
- Conditionally render the "Previously Searched" section based on the length of `allArticles`.
- Retain the rest of the functionalities untouched.

**Testing:**
- Ensure that the "Previously Searched" section only appears when there's at least one prior search.
- Validate that other functionalities within the `Demo` component remain operational.

**Reviewer Notes:**
Please check the conditional rendering logic to ensure there aren't any edge cases missed. Additionally, since this change impacts the UI directly, a brief visual review on different devices or screen sizes might be beneficial.
